### PR TITLE
Update 20250301-core-devs.md with correct Outdoor Wifi onboarding fees

### DIFF
--- a/releases/20250301-core-devs.md
+++ b/releases/20250301-core-devs.md
@@ -113,13 +113,13 @@ Mobile Hotspots are currently the only Hotspots that require burning a dollar de
 The current onboarding fees are as follows:
 
   - Wi-Fi Indoor: $10 DC, $10 MOBILE
-  - Wi-Fi Outdoor: $20 DC, $20 MOBILE
+  - Wi-Fi Outdoor: $10 DC, $20 MOBILE
   - Wi-Fi Data Only: $1 DC, $1 MOBILE
 
 These will be updated to the following:
 
   - Wi-Fi Indoor: $20 DC
-  - Wi-Fi Outdoor: $40 DC
+  - Wi-Fi Outdoor: $30 DC
   - Wi-Fi Data Only: $2 DC
 
 #### Alternatives Considered


### PR DESCRIPTION
The currently stated and proposed fees for outdoor wifi onboarding appear to be incorrect. HIP 96 specifies onboarding fees of $10 in DC and $20 in Mobile for Outdoor Wifi units, or $30 total. I am not aware of a change to this.